### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Turn Laravel 5 dot.based.translations into JSON-based translations",
     "license": "Unlicense",
     "require": {
-    	"laravel/framework": "~5.5"
+    	"laravel/framework": "5.5.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `~5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.